### PR TITLE
Fix Redis config path

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,9 +21,9 @@ import configuration from './config/configuration';
       provide: 'REDIS_CLIENT',
       useFactory: (configService: ConfigService) => {
         return new Redis({
-          host: configService.get<string>('redis.host'),
-          port: configService.get<number>('redis.port'),
-          password: configService.get<string>('redis.password'),
+          host: configService.get<string>('storage.redis.host'),
+          port: configService.get<number>('storage.redis.port'),
+          password: configService.get<string>('storage.redis.password'),
           retryStrategy: (times) => (times > 3 ? null : Math.min(times * 1000, 3000)),
         });
       },

--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -8,9 +8,9 @@ import Redis from 'ioredis';
       provide: 'REDIS_CLIENT',
       useFactory: (configService: ConfigService) => {
         return new Redis({
-          host: configService.get<string>('redis.host'),
-          port: configService.get<number>('redis.port'),
-          password: configService.get<string>('redis.password'),
+          host: configService.get<string>('storage.redis.host'),
+          port: configService.get<number>('storage.redis.port'),
+          password: configService.get<string>('storage.redis.password'),
           retryStrategy: (times) =>
             times > 3 ? null : Math.min(times * 1000, 3000),
         });


### PR DESCRIPTION
## Summary
- use correct storage.redis.* paths when constructing Redis client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fabd711083268c49d5829af2e249