### PR TITLE
Fix Redis provider override in e2e tests

### DIFF
--- a/test/location.e2e-spec.ts
+++ b/test/location.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('LocationController (e2e)', () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     })
-      .overrideProvider('RedisClient')
+      .overrideProvider('REDIS_CLIENT')
       .useValue(new RedisMock())
       .compile();
 


### PR DESCRIPTION
## Summary
- correct provider name in location e2e tests

## Testing
- `npm run test:e2e` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe0306ac83268a7ad864e161f1b8