### PR TITLE
Fix redis config keys

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,9 +21,9 @@ import configuration from './config/configuration';
       provide: 'REDIS_CLIENT',
       useFactory: (configService: ConfigService) => {
         return new Redis({
-          host: configService.get<string>('redis.host'),
-          port: configService.get<number>('redis.port'),
-          password: configService.get<string>('redis.password'),
+          host: configService.get<string>('storage.redis.host'),
+          port: configService.get<number>('storage.redis.port'),
+          password: configService.get<string>('storage.redis.password'),
           retryStrategy: (times) => (times > 3 ? null : Math.min(times * 1000, 3000)),
         });
       },


### PR DESCRIPTION
## Summary
- update Redis client config keys to read `storage.redis.*`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe05b2948326b06b7c4418724c45