### PR TITLE
Fix async health check test

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import Redis from 'ioredis';
+
+jest.mock('ioredis');
 
 /**
  * Unit tests for AppController.
@@ -9,17 +12,28 @@ describe('AppController', () => {
   let appController: AppController;
 
   beforeEach(async () => {
+    const mockRedisClient = {
+      ping: jest.fn().mockResolvedValue('PONG'),
+      info: jest.fn().mockResolvedValue(''),
+    } as Partial<jest.Mocked<Redis>>;
+
     const app: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [
+        AppService,
+        {
+          provide: 'REDIS_CLIENT',
+          useValue: mockRedisClient,
+        },
+      ],
     }).compile();
 
     appController = app.get<AppController>(AppController);
   });
 
   describe('health', () => {
-    it('should return health status', () => {
-      const result = appController.getHealth();
+    it('should return health status', async () => {
+      const result = await appController.getHealth();
       expect(result.status).toBe('ok');
       expect(result.timestamp).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- mock Redis client in controller spec
- await `getHealth()` in test

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe0800308326897d90c0319a897f