### PR TITLE
Update K8s README with Dockerfile info

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -8,9 +8,25 @@
 ## Build and Deploy
 
 1. Build the Docker image:
-```bash
-docker build -t geotools-api:latest .
-```
+   The repository doesn't ship with a `Dockerfile`. If you don't already have one,
+   create it in the project root before running `docker build`. Below is a minimal
+   example:
+
+   ```Dockerfile
+   FROM node:18
+   WORKDIR /app
+   COPY package*.json ./
+   RUN npm install --only=production
+   COPY . .
+   RUN npm run build
+   CMD ["node", "dist/main"]
+   ```
+
+   After creating the file, build the image:
+
+   ```bash
+   docker build -t geotools-api:latest .
+   ```
 
 2. Create base64 encoded cities data:
 ```bash


### PR DESCRIPTION
## Summary
- clarify that the repository does not include a Dockerfile
- provide a minimal Dockerfile example and build steps in Kubernetes README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe0af2748326bb67d74115f17df9